### PR TITLE
52 rastertools ecriture optionnelle

### DIFF
--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -139,7 +139,7 @@ class Hillshade(Rastertool, Windowable):
                              f"value={min(self.window_size)})")
 
         # Configure the processing
-        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.ubyte,
+        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.int8,
                                      nbits=1, compress='lzw', per_band_algo=True)
         hillshade.with_arguments({
             "elevation": None,

--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -139,7 +139,7 @@ class Hillshade(Rastertool, Windowable):
                              f"value={min(self.window_size)})")
 
         # Configure the processing
-        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.int8,
+        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.int8, processing_dtype=np.float32,
                                      nbits=1, compress='lzw', per_band_algo=True)
         hillshade.with_arguments({
             "elevation": None,

--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -139,8 +139,8 @@ class Hillshade(Rastertool, Windowable):
                              f"value={min(self.window_size)})")
 
         # Configure the processing
-        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.float32,
-                                     per_band_algo=True)
+        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.ubyte,
+                                     nbits=1, compress='lzw', per_band_algo=True)
         hillshade.with_arguments({
             "elevation": None,
             "azimuth": None,

--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -139,7 +139,7 @@ class Hillshade(Rastertool, Windowable):
                              f"value={min(self.window_size)})")
 
         # Configure the processing
-        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.int8, processing_dtype=np.float32,
+        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.int8, in_dtype=np.float32,
                                      nbits=1, compress='lzw', per_band_algo=True)
         hillshade.with_arguments({
             "elevation": None,

--- a/src/eolab/rastertools/processing/algo.py
+++ b/src/eolab/rastertools/processing/algo.py
@@ -493,7 +493,7 @@ def hillshade(input_data, **kwargs):
 
     # initialize output
     shape = input_data.shape
-    out = np.zeros(shape, dtype=np.float32)
+    out = np.zeros(shape, dtype=bool)
 
     # prevent nodata problem
     input_band = np.nan_to_num(input_data[0], copy=False, nan=0)
@@ -513,7 +513,6 @@ def hillshade(input_data, **kwargs):
 
     angles = np.arctan(ratios)
     out[0, radius: shape[1] - radius, radius: shape[2] - radius] = angles > elevation
-
     return out
 
 

--- a/src/eolab/rastertools/processing/algo.py
+++ b/src/eolab/rastertools/processing/algo.py
@@ -513,6 +513,7 @@ def hillshade(input_data, **kwargs):
 
     angles = np.arctan(ratios)
     out[0, radius: shape[1] - radius, radius: shape[2] - radius] = angles > elevation
+
     return out
 
 

--- a/src/eolab/rastertools/processing/rasterproc.py
+++ b/src/eolab/rastertools/processing/rasterproc.py
@@ -19,6 +19,7 @@ class RasterProcessing:
                  algo: Callable = None,
                  nodata: float = None,
                  dtype: np.dtype = None,
+                 processing_dtype: np.dtype = None,
                  compress: str = None,
                  nbits: int = False,
                  per_band_algo: bool = False):
@@ -37,6 +38,9 @@ class RasterProcessing:
             dtype (rasterio or numpy data type, optional, default=None):
                 Type of generated data. When None, the generated data are supposed
                 to be of the same type as input data.
+            processing_dtype (rasterio or numpy data type, optional, default=None):
+                Type of processed data. When None, the processed data are supposed
+                to be of the same type as input data.
             compress (str, optional, default=None):
                 Set the compression to use.
             nbits (int, optional, default=None):
@@ -51,6 +55,7 @@ class RasterProcessing:
         self._per_band_algo = per_band_algo
         self._nodata = nodata
         self._dtype = dtype
+        self._processing_dtype = processing_dtype
         self._compress = compress
         self._nbits = nbits
         self._arguments = dict()
@@ -83,6 +88,11 @@ class RasterProcessing:
     def dtype(self):
         """Type of the generated data"""
         return self._dtype
+
+    @property
+    def processing_dtype(self):
+        """Type of the processed data"""
+        return self._processing_dtype
 
     @property
     def compress(self) -> str:

--- a/src/eolab/rastertools/processing/rasterproc.py
+++ b/src/eolab/rastertools/processing/rasterproc.py
@@ -19,7 +19,7 @@ class RasterProcessing:
                  algo: Callable = None,
                  nodata: float = None,
                  dtype: np.dtype = None,
-                 processing_dtype: np.dtype = None,
+                 in_dtype: np.dtype = None,
                  compress: str = None,
                  nbits: int = False,
                  per_band_algo: bool = False):
@@ -38,7 +38,7 @@ class RasterProcessing:
             dtype (rasterio or numpy data type, optional, default=None):
                 Type of generated data. When None, the generated data are supposed
                 to be of the same type as input data.
-            processing_dtype (rasterio or numpy data type, optional, default=None):
+            in_dtype (rasterio or numpy data type, optional, default=None):
                 Type of processed data. When None, the processed data are supposed
                 to be of the same type as dtype parameter.
             compress (str, optional, default=None):
@@ -55,7 +55,7 @@ class RasterProcessing:
         self._per_band_algo = per_band_algo
         self._nodata = nodata
         self._dtype = dtype
-        self._processing_dtype = processing_dtype
+        self._in_dtype = in_dtype
         self._compress = compress
         self._nbits = nbits
         self._arguments = dict()
@@ -90,9 +90,9 @@ class RasterProcessing:
         return self._dtype
 
     @property
-    def processing_dtype(self):
+    def in_dtype(self):
         """Type of the processed data"""
-        return self._processing_dtype
+        return self._in_dtype
 
     @property
     def compress(self) -> str:

--- a/src/eolab/rastertools/processing/rasterproc.py
+++ b/src/eolab/rastertools/processing/rasterproc.py
@@ -40,7 +40,7 @@ class RasterProcessing:
                 to be of the same type as input data.
             processing_dtype (rasterio or numpy data type, optional, default=None):
                 Type of processed data. When None, the processed data are supposed
-                to be of the same type as input data.
+                to be of the same type as dtype parameter.
             compress (str, optional, default=None):
                 Set the compression to use.
             nbits (int, optional, default=None):

--- a/src/eolab/rastertools/processing/rasterproc.py
+++ b/src/eolab/rastertools/processing/rasterproc.py
@@ -41,7 +41,7 @@ class RasterProcessing:
                 Set the compression to use.
             nbits (int, optional, default=None):
                 Create a file with less than 8 bits per sample by passing a value from
-                1 to 7. The apparent pixel type shoul be Byte.
+                1 to 7. The apparent pixel type should be Byte.
             per_band_algo (bool, optional, default=False):
                 Whether the algo is applied on a dataset that contains only one band
                 (per_band_algo=True) or on a dataset with all bands (per_band_algo=False)

--- a/src/eolab/rastertools/processing/rasterproc.py
+++ b/src/eolab/rastertools/processing/rasterproc.py
@@ -19,6 +19,8 @@ class RasterProcessing:
                  algo: Callable = None,
                  nodata: float = None,
                  dtype: np.dtype = None,
+                 compress: str = None,
+                 nbits: int = False,
                  per_band_algo: bool = False):
         """Constructor
 
@@ -35,6 +37,11 @@ class RasterProcessing:
             dtype (rasterio or numpy data type, optional, default=None):
                 Type of generated data. When None, the generated data are supposed
                 to be of the same type as input data.
+            compress (str, optional, default=None):
+                Set the compression to use.
+            nbits (int, optional, default=None):
+                Create a file with less than 8 bits per sample by passing a value from
+                1 to 7. The apparent pixel type shoul be Byte.
             per_band_algo (bool, optional, default=False):
                 Whether the algo is applied on a dataset that contains only one band
                 (per_band_algo=True) or on a dataset with all bands (per_band_algo=False)
@@ -44,6 +51,8 @@ class RasterProcessing:
         self._per_band_algo = per_band_algo
         self._nodata = nodata
         self._dtype = dtype
+        self._compress = compress
+        self._nbits = nbits
         self._arguments = dict()
 
     def __repr__(self) -> str:
@@ -74,6 +83,16 @@ class RasterProcessing:
     def dtype(self):
         """Type of the generated data"""
         return self._dtype
+
+    @property
+    def compress(self) -> str:
+        """Set the compression to use"""
+        return self._compress
+
+    @property
+    def nbits(self) -> int:
+        """bits size of the generated data"""
+        return self._nbits
 
     @property
     def description(self):

--- a/src/eolab/rastertools/processing/sliding.py
+++ b/src/eolab/rastertools/processing/sliding.py
@@ -60,7 +60,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
             dtype = rasterprocessing.dtype or rasterio.float32
             processing_dtype = rasterprocessing.processing_dtype or dtype
             nbits = rasterprocessing.nbits
-            compress = rasterprocessing.compress
+            compress = rasterprocessing.compress or src.compression or 'lzw'
             nodata = rasterprocessing.nodata or src.nodata
 
             # check band index and handle all bands options (when bands is an empty list)

--- a/src/eolab/rastertools/processing/sliding.py
+++ b/src/eolab/rastertools/processing/sliding.py
@@ -58,7 +58,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
 
             # dtype and creation options of output data
             dtype = rasterprocessing.dtype or rasterio.float32
-            processing_dtype = rasterprocessing.processing_dtype or dtype
+            in_dtype = rasterprocessing.in_dtype or dtype
             nbits = rasterprocessing.nbits
             compress = rasterprocessing.compress or src.compression or 'lzw'
             nodata = rasterprocessing.nodata or src.nodata
@@ -102,7 +102,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
     process_map(_process_sliding, repeat(rasterprocessing),
                 repeat(input_image), repeat(output_image),
                 sliding_windows_bands, repeat(window_overlap),
-                repeat(pad_mode), repeat(processing_dtype),
+                repeat(pad_mode), repeat(in_dtype),
                 repeat(write_lock),
                 **kwargs)
 

--- a/src/eolab/rastertools/processing/sliding.py
+++ b/src/eolab/rastertools/processing/sliding.py
@@ -57,8 +57,8 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
                 blockysize = utils.highest_power_of_2(src.height)
 
             # dtype and creation options of output data
-            dtype_algo = np.float32 or rasterio.float32
-            dtype = rasterprocessing.dtype
+            dtype = rasterprocessing.dtype or rasterio.float32
+            processing_dtype = rasterprocessing.processing_dtype or dtype
             nbits = rasterprocessing.nbits
             compress = rasterprocessing.compress
             nodata = rasterprocessing.nodata or src.nodata
@@ -71,7 +71,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
 
             # setup profile for output image
             profile.update(driver='GTiff', blockxsize=blockxsize, blockysize=blockysize,
-                           tiled=True, dtype=dtype, nbits=nbits, compress = compress,
+                           tiled=True, dtype=dtype, nbits=nbits, compress=compress,
                            nodata=nodata, count=len(bands))
 
             with rasterio.open(output_image, "w", **profile):
@@ -102,7 +102,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
     process_map(_process_sliding, repeat(rasterprocessing),
                 repeat(input_image), repeat(output_image),
                 sliding_windows_bands, repeat(window_overlap),
-                repeat(pad_mode), repeat(dtype_algo),
+                repeat(pad_mode), repeat(processing_dtype),
                 repeat(write_lock),
                 **kwargs)
 

--- a/src/eolab/rastertools/processing/sliding.py
+++ b/src/eolab/rastertools/processing/sliding.py
@@ -56,8 +56,13 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
             if src.height < blockysize:
                 blockysize = utils.highest_power_of_2(src.height)
 
-            # dtype of output data
-            dtype = rasterprocessing.dtype or rasterio.float32
+            # dtype and creation options of output data
+            dtype_algo = np.float32 or rasterio.float32
+            dtype = rasterprocessing.dtype
+            nbits = rasterprocessing.nbits
+            compress = rasterprocessing.compress
+            nodata = rasterprocessing.nodata or src.nodata
+
             # check band index and handle all bands options (when bands is an empty list)
             if bands is None or len(bands) == 0:
                 bands = src.indexes
@@ -65,10 +70,9 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
                 raise ValueError(f"Invalid bands, all values are not in range [1, {src.count}]")
 
             # setup profile for output image
-            profile.update(driver='GTiff', compress='lzw',
-                           blockxsize=blockxsize, blockysize=blockysize, tiled=True,
-                           dtype=np.int8, nodata=rasterprocessing.nodata or src.nodata,
-                           count=len(bands))
+            profile.update(driver='GTiff', blockxsize=blockxsize, blockysize=blockysize,
+                           tiled=True, dtype=dtype, nbits=1, compress = compress,
+                           nodata=nodata, count=len(bands))
 
             with rasterio.open(output_image, "w", **profile):
                 # file is created
@@ -98,7 +102,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
     process_map(_process_sliding, repeat(rasterprocessing),
                 repeat(input_image), repeat(output_image),
                 sliding_windows_bands, repeat(window_overlap),
-                repeat(pad_mode), repeat(dtype),
+                repeat(pad_mode), repeat(dtype_algo),
                 repeat(write_lock),
                 **kwargs)
 

--- a/src/eolab/rastertools/processing/sliding.py
+++ b/src/eolab/rastertools/processing/sliding.py
@@ -58,7 +58,6 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
 
             # dtype of output data
             dtype = rasterprocessing.dtype or rasterio.float32
-
             # check band index and handle all bands options (when bands is an empty list)
             if bands is None or len(bands) == 0:
                 bands = src.indexes
@@ -68,7 +67,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
             # setup profile for output image
             profile.update(driver='GTiff', compress='lzw',
                            blockxsize=blockxsize, blockysize=blockysize, tiled=True,
-                           dtype=dtype, nodata=rasterprocessing.nodata or src.nodata,
+                           dtype=np.int8, nodata=rasterprocessing.nodata or src.nodata,
                            count=len(bands))
 
             with rasterio.open(output_image, "w", **profile):

--- a/src/eolab/rastertools/processing/sliding.py
+++ b/src/eolab/rastertools/processing/sliding.py
@@ -66,7 +66,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
                 raise ValueError(f"Invalid bands, all values are not in range [1, {src.count}]")
 
             # setup profile for output image
-            profile.update(driver='GTiff',
+            profile.update(driver='GTiff', compress='lzw',
                            blockxsize=blockxsize, blockysize=blockysize, tiled=True,
                            dtype=dtype, nodata=rasterprocessing.nodata or src.nodata,
                            count=len(bands))

--- a/src/eolab/rastertools/processing/sliding.py
+++ b/src/eolab/rastertools/processing/sliding.py
@@ -71,7 +71,7 @@ def compute_sliding(input_image: str, output_image: str, rasterprocessing: Raste
 
             # setup profile for output image
             profile.update(driver='GTiff', blockxsize=blockxsize, blockysize=blockysize,
-                           tiled=True, dtype=dtype, nbits=1, compress = compress,
+                           tiled=True, dtype=dtype, nbits=nbits, compress = compress,
                            nodata=nodata, count=len(bands))
 
             with rasterio.open(output_image, "w", **profile):


### PR DESCRIPTION
Add the lwz compression to hillshade final output :  

- For the given DEM 25WFS with customized parameters, 
rastertools output size without compression is 151MB
rastertools output size with lzw compression is 1.1MB
--> Results look exactly the same, huge memory space is freed.
--> No negative impact known.

- I tests a dtype = np.uint8 (instead of default np.float32),
rastertools output size with lzw compression is 0.77MB
--> Results look exactly the same, a bit more space could be freed.
--> But as np.nan - which is typed Float - can be encountered in our data, it requires further research to implement a change in dtype.
