### PR TITLE
add setter to attribute radius to make it modifiable

### DIFF
--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -92,6 +92,12 @@ class Hillshade(Rastertool, Windowable):
         for evaluating the max elevation angle"""
         return self._radius
 
+    @radius.setter
+    def radius(self, value):
+        """Set distance from current point (in pixels) to consider
+        for evaluating the max elevation angle"""
+        self._radius = value
+
     def process_file(self, inputfile: str) -> List[str]:
         """Compute Hillshade for the input file
 

--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -92,12 +92,6 @@ class Hillshade(Rastertool, Windowable):
         for evaluating the max elevation angle"""
         return self._radius
 
-    @radius.setter
-    def radius(self, value):
-        """Set distance from current point (in pixels) to consider
-        for evaluating the max elevation angle"""
-        self._radius = value
-
     def process_file(self, inputfile: str) -> List[str]:
         """Compute Hillshade for the input file
 
@@ -132,7 +126,7 @@ class Hillshade(Rastertool, Windowable):
         optimal_radius = int(delta / np.tan(np.radians(self.elevation)))
 
         if self.radius is None or optimal_radius <= self.radius:
-            self.radius = optimal_radius
+            self._radius = optimal_radius
             _logger.info(f"Using optimal radius {self.radius} for hillshade computation")
         else:
             _logger.warning(f"The optimal radius value is {optimal_radius} exceeding {self.radius} threshold. "


### PR DESCRIPTION
In hillshade.py we can encounter an error at `self.radius = optimal_radius`.
In object-oriented programming language as python, setting a new value to a private class attribute (decorator @property) is possible if the attribute has a setter defined (decorator @attr.setter). As self.radius is the only attribute which is modified in peculiar cases, we never encountered this error before.

After testing this solution I encounter no more error