### PR TITLE
Add nodata value to hillshade output

### DIFF
--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -139,8 +139,16 @@ class Hillshade(Rastertool, Windowable):
                              f"value={min(self.window_size)})")
 
         # Configure the processing
-        hillshade = RasterProcessing("hillshade", algo=algo.hillshade, dtype=np.int8, in_dtype=np.float32,
-                                     nbits=1, compress='lzw', per_band_algo=True)
+        hillshade = RasterProcessing(
+            "hillshade",
+            algo=algo.hillshade,
+            nodata=255,
+            dtype=np.int8,
+            in_dtype=np.float32,
+            nbits=1,
+            compress="lzw",
+            per_band_algo=True,
+        )
         hillshade.with_arguments({
             "elevation": None,
             "azimuth": None,

--- a/src/eolab/rastertools/hillshade.py
+++ b/src/eolab/rastertools/hillshade.py
@@ -143,7 +143,7 @@ class Hillshade(Rastertool, Windowable):
             "hillshade",
             algo=algo.hillshade,
             nodata=255,
-            dtype=np.int8,
+            dtype=np.uint8,
             in_dtype=np.float32,
             nbits=1,
             compress="lzw",


### PR DESCRIPTION
Hillshade: Set the `nodata` parameter of the `RasterProcessing` used to compute hillshade mask. When this parameter is not set, the `nodata` of the input raster is used and can be outside of the scope of `np.uint8`